### PR TITLE
Fix battery symbol

### DIFF
--- a/boards/shields/dongle_display/widgets/battery_status.c
+++ b/boards/shields/dongle_display/widgets/battery_status.c
@@ -33,6 +33,11 @@ struct battery_state {
     uint8_t level;
     bool usb_present;
 };
+
+struct battery_object {
+    lv_obj_t *symbol;
+    lv_obj_t *label;
+} battery_objects[ZMK_SPLIT_CENTRAL_PERIPHERAL_COUNT + SOURCE_OFFSET];
     
 static lv_color_t battery_image_buffer[ZMK_SPLIT_CENTRAL_PERIPHERAL_COUNT + SOURCE_OFFSET][5 * 8];
 
@@ -69,15 +74,17 @@ static void set_battery_symbol(lv_obj_t *widget, struct battery_state state) {
         return;
     }
     LOG_DBG("source: %d, level: %d, usb: %d", state.source, state.level, state.usb_present);
-    lv_obj_t *symbol = lv_obj_get_child(widget, state.source * 2);
-    lv_obj_t *label = lv_obj_get_child(widget, state.source * 2 + 1);
+    lv_obj_t *symbol = battery_objects[state.source].symbol;
+    lv_obj_t *label = battery_objects[state.source].label;
 
     draw_battery(symbol, state.level, state.usb_present);
     lv_label_set_text_fmt(label, "%4u%%", state.level);
     
     if (state.level > 0 || state.usb_present) {
         lv_obj_clear_flag(symbol, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_move_foreground(symbol);
         lv_obj_clear_flag(label, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_move_foreground(label);
     } else {
         lv_obj_add_flag(symbol, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(label, LV_OBJ_FLAG_HIDDEN);
@@ -147,6 +154,11 @@ int zmk_widget_dongle_battery_status_init(struct zmk_widget_dongle_battery_statu
 
         lv_obj_add_flag(image_canvas, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(battery_label, LV_OBJ_FLAG_HIDDEN);
+        
+        battery_objects[i] = (struct battery_object){
+            .symbol = image_canvas,
+            .label = battery_label,
+        };
     }
 
     sys_slist_append(&widgets, &widget->node);


### PR DESCRIPTION
When no peripherals are connected and the central is not connected by USB (battery-powered), the battery status was not displayed. This is fixed by moving the corresponding symbol into the foreground. Unfortunately this messes up the object ordering, so the pointers have to be stored separately.

See #9