### PR TITLE
.Revert to c6c4be1 and pin ZMK to v0.3.0

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -7,7 +7,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: v0.3.0
+      revision: v0.3
       import: app/west.yml
     - name: zmk-config
       remote: englmaxi


### PR DESCRIPTION
- Reset repository to commit c6c4be1 (Allow bigger layer names without scrolling)
- Pin ZMK to version v0.3.0 in west.yml