### PR TITLE
Add throttling and NULL checks to prevent display freeze during rapid key events

### DIFF
--- a/boards/shields/dongle_display/Kconfig.defconfig
+++ b/boards/shields/dongle_display/Kconfig.defconfig
@@ -63,10 +63,10 @@ choice ZMK_DISPLAY_WORK_QUEUE
 endchoice
 
 config LV_Z_MEM_POOL_SIZE
-    default 8192
+    default 16384
 
 config LV_Z_VDB_SIZE
-    default 64
+    default 100
 
 config LV_DPI_DEF
     default 148


### PR DESCRIPTION
### Problem

When using macros that send multiple modifier keys rapidly (e.g., `Ctrl+Alt+Cmd+F1`), the display would freeze and the keyboard would become unresponsive, requiring a restart.

### Root Cause

Both `bongo_cat.c` and `wpm_status.c` subscribe to `zmk_wpm_state_changed` events. Every keystroke triggers **two separate callback chains** through the display thread:

```
Keystroke → zmk_wpm_state_changed event
                    ↓
    ┌───────────────┴───────────────┐
    ↓                               ↓
wpm_status callback          bongo_cat callback
    ↓                               ↓
lv_label_set_text()         lv_animimg_start()
```

During rapid keypresses or macros with multiple modifiers, this floods the display thread. The `lv_animimg_start()` call is particularly expensive as it involves memory allocation and timer setup.

Additionally, `wpm_status.c` has a NULL pointer bug - `zmk_keymap_layer_name()` can return NULL if a layer doesn't have a `display-name` or `label`, causing `strstr()` to crash.

### Changes

**`widgets/wpm_status.c`**:
- Add 250ms throttling interval (max 4 display updates per second)
- Add NULL check for `state.layer` before `strstr()` call

**`widgets/bongo_cat.c`**:
- Add 200ms throttling interval (max 5 animation state checks per second)
- Add NULL check for event pointer in `get_state()`

**`Kconfig.defconfig`**:
- Increase `LV_Z_MEM_POOL_SIZE` from 8192 to 16384 for animation headroom
- Increase `LV_Z_VDB_SIZE` from 64 to 100 for smoother rendering

### Testing

Tested with:
- ZMK 4.0 / Zephyr 4.1
- Charybdis split keyboard with nice!nano dongle + 128x64 OLED
- Macros using `Ctrl+Alt+Cmd+F1` through `F12` (rapid multi-modifier keypresses)
- WPM widget enabled alongside Bongo Cat animation

Previously caused consistent freezes, now stable with throttling in place. I'm running on this now, after couple working days I'll report. Lets not merge this for couple of days.
